### PR TITLE
Add flag to ignore not loaded warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Now that you have an app created, switch over to that app's Settings tab and cop
       "appId": "XXXXXXXXXXXXXXXXXXX",
       "disableUserTracking": true,
       "disableRouteTracking": true,
-      "disableMethodTracking": true
+      "disableMethodTracking": true,
+      "ignoreNotFoundWarning": false
     }
   }
 }
@@ -55,6 +56,8 @@ Now that you have an app created, switch over to that app's Settings tab and cop
 `disableRouteTracking`: `true` or `false`, optional.  This sends a Page call as routing is engaged within your Meteor App.
 
 `disableMethodTracking`: `true` or `false`, optional.  This sends a Track call as methods are engaged within your Meteor App.
+
+`ignoreNotFoundWarning`: `true` or `false`, optional. This prevents a warning from appearing in the console if there is no `appId`.
 
 # 4. Run your Meteor app & see events!
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
     name: 'astronomerio:core',
-    version: '1.0.0',
+    version: '1.0.1',
     summary: 'Easily push analytics events to Astronomer.',
     git: 'https://github.com/astronomerio/meteor-astronomer',
     documentation: 'README.md'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-astronomer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "package.js",
   "scripts": {

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,6 @@ for (let t = 0; t < analytics.methods.length; t++) {
 // Assign real analytics if we have an appId.
 if (settings.appId) {
     analytics = new Analytics(settings.appId);
-} else {
+} else if (! settings.ignoreNotFoundWarning) {
     console.warn('Astronomer settings not found in Meteor.settings, skipping setup.');
 }

--- a/src/tracking.js
+++ b/src/tracking.js
@@ -142,7 +142,7 @@ function initialize() {
         if (!settings.disableUserTracking) setupIdentify();
         if (!settings.disableRouteTracking) setupRouteTracking();
         if (!settings.disableMethodTracking) setupMethodTracking();
-    } else {
+    } else if (! settings.ignoreNotFoundWarning) {
         console.warn('Astronomer settings not found in Meteor.settings, skipping setup.');
     }
 }


### PR DESCRIPTION
If in development or on a staging server, you may not want to enable Astronomer. In that case, you probably don't want to see the warning about skipping setup. This allows for that.