### PR TITLE
Prevent weak dependencies from failing

### DIFF
--- a/dist/tracking.js
+++ b/dist/tracking.js
@@ -30,7 +30,9 @@ function emailAddress(user) {
  */
 function setupIdentify() {
     if (Package['accounts-base']) {
-        Tracker.autorun(function () {
+        const Tracker = require('meteor/tracker').Tracker;
+        if (Tracker) {
+          Tracker.autorun(function () {
             const user = AstronomerUser.findOne() || {};
 
             const id = user._id;
@@ -40,7 +42,11 @@ function setupIdentify() {
             traits.email = emailAddress(user);
 
             analytics.identify(id, traits);
-        });
+          });
+        }
+        else {
+          console.warn('Tracker not detected, User changes cannot be monitored, all events will be anonymous.')
+        }
     } else {
         console.warn('Meteor accounts not detected, all events will be anonymous.');
     }
@@ -59,6 +65,8 @@ function setupRouteTracking() {
 
     if (Package['iron:router']) {
         /** Setup Iron Router */
+        const Router = require('meteor/iron:router').Router;
+
         Router.onRun(function () {
             let _this = this;
 
@@ -82,6 +90,10 @@ function setupRouteTracking() {
         });
     } else if (Package['meteorhacks:flow-router'] || Package['kadira:flow-router']) {
         /** Setup Flow Router */
+        let FlowRouter;
+        if (Package['meteorhacks:flow-router']) FlowRouter = Package['meteorhacks:flow-router'].FlowRouter;
+        if (Package['kadira:flow-router']) FlowRouter = Package['kadira:flow-router'].FlowRouter;
+
         FlowRouter.triggers.enter([function (context) {
             /** Build properties to pass along with page */
             const routeParams = context.params;

--- a/package.js
+++ b/package.js
@@ -17,11 +17,12 @@ Package.onUse(function(api) {
         'underscore',
         'mongo'
     ]);
-    
+
     api.mainModule('client.js', 'client');
     api.mainModule('server.js', 'server');
 
     api.use(['accounts-base', 'accounts-oauth'], { weak: true });
+    api.use('tracker', 'client', { weak: true });
     api.use('iron:router@1.0.7', 'client', { weak: true });
     api.use('meteorhacks:flow-router@1.17.2', 'client', { weak: true });
     api.use('kadira:flow-router@2.0.0', 'client', { weak: true });

--- a/src/tracking.js
+++ b/src/tracking.js
@@ -30,7 +30,9 @@ function emailAddress(user) {
  */
 function setupIdentify() {
     if (Package['accounts-base']) {
-        Tracker.autorun(function () {
+        const Tracker = require('meteor/tracker').Tracker;
+        if (Tracker) {
+          Tracker.autorun(function () {
             const user = AstronomerUser.findOne() || {};
 
             const id = user._id;
@@ -40,7 +42,11 @@ function setupIdentify() {
             traits.email = emailAddress(user);
 
             analytics.identify(id, traits);
-        });
+          });
+        }
+        else {
+          console.warn('Tracker not detected, User changes cannot be monitored, all events will be anonymous.')
+        }
     } else {
         console.warn('Meteor accounts not detected, all events will be anonymous.');
     }
@@ -59,6 +65,8 @@ function setupRouteTracking() {
 
     if (Package['iron:router']) {
         /** Setup Iron Router */
+        const Router = require('meteor/iron:router').Router;
+
         Router.onRun(function () {
             let _this = this;
 
@@ -82,6 +90,10 @@ function setupRouteTracking() {
         });
     } else if (Package['meteorhacks:flow-router'] || Package['kadira:flow-router']) {
         /** Setup Flow Router */
+        let FlowRouter;
+        if (Package['meteorhacks:flow-router']) FlowRouter = Package['meteorhacks:flow-router'].FlowRouter;
+        if (Package['kadira:flow-router']) FlowRouter = Package['kadira:flow-router'].FlowRouter;
+
         FlowRouter.triggers.enter([function (context) {
             /** Build properties to pass along with page */
             const routeParams = context.params;


### PR DESCRIPTION
We have come across an issue where the test build of our application fails because of weak and assumed dependencies.

When our tests run on Travis, we get an error thrown as follows:

```
Script Error: ReferenceError: Tracker is not defined
       Stack:
         -> http://localhost:3000/packages/astronomerio_core.js?hash=5f995017f3573ae7466346d420c60d440234de26: 121 (in function setupIdentify)
         -> http://localhost:3000/packages/astronomerio_core.js?hash=5f995017f3573ae7466346d420c60d440234de26: 221 (in function initialize)
         -> http://localhost:3000/packages/meteor.js?hash=814eae5b938a9a89ce7cf9174c98be4982f953d8: 813 (in function maybeReady)
         -> http://localhost:3000/packages/meteor.js?hash=814eae5b938a9a89ce7cf9174c98be4982f953d8: 825 (in function loadingCompleted)
```

This fixes the issue by not relying on assumed globals