### PR TITLE
Remove templating

### DIFF
--- a/.versions
+++ b/.versions
@@ -43,7 +43,6 @@ retry@1.0.7
 routepolicy@1.0.10
 spacebars@1.0.11
 spacebars-compiler@1.0.11
-templating@1.1.9
 templating-tools@1.0.4
 tinytest@1.0.10
 tracker@1.0.13

--- a/package.js
+++ b/package.js
@@ -13,7 +13,6 @@ Package.onUse(function(api) {
 
     api.use([
         'ecmascript',
-        'templating',
         'underscore',
         'mongo'
     ]);


### PR DESCRIPTION
Resolves this open issue: https://github.com/astronomerio/meteor-astronomer/issues/24
Tested locally and confirmed no dependency on templating is required.